### PR TITLE
Updates default order status from pending to ordered

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -10,7 +10,6 @@
 #
 class Order < ApplicationRecord
   enum status: {
-    pending: "pending",
     ordered: "ordered",
     cancelled: "cancelled"
   }

--- a/db/migrate/20200722130835_change_default_value_orders.rb
+++ b/db/migrate/20200722130835_change_default_value_orders.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultValueOrders < ActiveRecord::Migration[6.0]
+  def change
+    change_column :orders, :status, :string, default: 'ordered'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_21_212541) do
+ActiveRecord::Schema.define(version: 2020_07_22_130835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2020_07_21_212541) do
     t.integer "cart_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "status", default: "pending"
+    t.string "status", default: "ordered"
   end
 
   create_table "products", force: :cascade do |t|


### PR DESCRIPTION
## Summary
An order should only ever be created if the order has been placed. Thus, the default status for an order should be `ordered` rather than `pending`.

The `pending` status has also been removed, as a result. And the database has been reset to accommodate this change.